### PR TITLE
docs: document branch protection requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,12 +233,20 @@ Users must explicitly set service.type=LoadBalancer or configure ingress."
 
 ### PR Requirements
 
-- ✅ Passes all CI checks (lint, tests, security scans)
+**Branch Protection:** The `main` branch is protected. All changes must go through pull requests.
+
+Required for merge:
+- ✅ **1 approving review** from a maintainer
+- ✅ **Passing status checks:**
+  - Build and Test
+  - Scorecard analysis (security)
+- ✅ **All conversations resolved**
 - ✅ Includes tests for new features
 - ✅ Updates documentation
 - ✅ Follows conventional commit format
 - ✅ No merge conflicts with main
-- ✅ Approved by maintainer
+
+**Note:** Stale reviews are automatically dismissed when new commits are pushed.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `CONTRIBUTING.md` to document the newly enabled branch protection rules on the `main` branch.

## Changes

- Added explicit statement that `main` branch is protected
- Documented requirement for 1 approving review from maintainer
- Listed required status checks (Build and Test, Scorecard analysis)
- Noted that conversations must be resolved before merge
- Added note about automatic stale review dismissal

## Why

Branch protection was just enabled to improve the repository's OpenSSF Scorecard Code-Review score. Contributors need clear documentation about the new PR requirements.

## Test Plan

- [x] Documentation change only - no functional changes to test
- [x] Verified formatting renders correctly in markdown
- [x] Information matches actual branch protection settings