### PR TITLE
feat(security): add StepSecurity harden-runner to audit network egress

### DIFF
--- a/.github/workflows/build-tools-image.yml
+++ b/.github/workflows/build-tools-image.yml
@@ -32,6 +32,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -71,6 +76,11 @@ jobs:
       packages: write     # For pushing images to GHCR
       id-token: write     # For cosign keyless signing
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,11 @@ jobs:
       contents: read          # For checking out code
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -34,7 +39,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload ShellCheck SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@42213152a85ae7569bdb6bec7bcd74cd691bfe41 # v3.30.9
         with:
           sarif_file: shellcheck.sarif
           category: shellcheck
@@ -46,6 +51,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
## Summary

Adds StepSecurity's harden-runner action to all workflows to improve supply chain security by auditing network calls during CI/CD execution.

## What is Harden-Runner?

Harden-runner is a GitHub Action that monitors all network calls made during a workflow run. It helps detect:
- Compromised GitHub Actions
- Malicious dependencies
- Unexpected network activity
- Supply chain attacks

## Changes

Added `step-security/harden-runner@v2.13.1` to all workflow jobs:

### `.github/workflows/codeql.yml`
- shellcheck job: audit network egress
- yaml-lint job: audit network egress
- Pin CodeQL upload-sarif action to commit SHA

### `.github/workflows/build-tools-image.yml`
- build-and-test job: audit network egress
- publish-main job: audit network egress

## Security Benefits

| Benefit | Description |
|---------|-------------|
| **Supply Chain Monitoring** | Logs all outbound network calls to detect anomalies |
| **Compromised Action Detection** | Identifies if an action makes unexpected network requests |
| **Audit Trail** | Provides visibility into external dependencies accessed |
| **Defense in Depth** | Additional security layer beyond dependency pinning |

## How It Works

1. **Audit Mode**: Logs all network egress without blocking (non-breaking)
2. **Visibility**: Audit logs available in workflow run details
3. **Detection**: Alerts if unexpected domains are accessed
4. **Pinned**: Action is pinned by commit SHA for supply chain security

## Example Detection Scenarios

Harden-runner would detect if:
- A pinned action is compromised and makes unexpected network calls
- A dependency installation script contacts an unknown server
- Build tools attempt to exfiltrate data to external services
- Malicious code tries to download payloads from attacker-controlled domains

## Configuration

```yaml
- name: Harden the runner (Audit all outbound calls)
  uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
  with:
    egress-policy: audit
```

- **egress-policy: audit** - Log all network calls without blocking
- **Pinned to commit SHA** - Prevents action from being compromised

## Test Plan

- [x] Harden-runner added to all jobs in affected workflows
- [x] egress-policy set to audit (non-breaking)
- [x] Actions pinned to commit SHA
- [x] No workflow functionality impacted

## What's Next

After merge:
1. Monitor workflow runs for audit logs
2. Review network egress patterns to establish baseline
3. Consider moving to `egress-policy: block` with allowed list in the future
4. Extend to other workflows as they're added

## Related

- StepSecurity Harden-Runner: https://github.com/step-security/harden-runner
- OpenSSF Scorecard recognition: Harden-runner usage is a positive signal